### PR TITLE
Use the dedicated polyfill package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,6 @@
         }
     ],
     "require": {
-        "symfony/polyfill": "^1.27"
+        "symfony/polyfill-php81": "^1.27"
     }
 }


### PR DESCRIPTION
Using the full symfony/polyfill package is [discouraged by the Symfony team](https://github.com/symfony/polyfill/tree/1.x#usage). Individual packages should be used instead.

Note that this decreases the size of the installed vendors a lot as the php81 polyfill is a very small one (the iconv polyfill is huge for instance as it needs data about all encodings)